### PR TITLE
Add an option to keep users logged in for longer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ $wgOAuth2Client['configuration']['scopes'] = 'read_citizen_info'; //Permissions
 
 $wgOAuth2Client['configuration']['service_name'] = 'Citizen Registry'; // the name of your service
 $wgOAuth2Client['configuration']['service_login_link_text'] = 'Login with StarMade'; // the text of the login link
+$wgOAuth2Client['configuration']['remember_me'] = true; // Whether to keep user logged in for longer, similarly to what would happen if they checked "Keep me logged in" in password-based login. See https://www.mediawiki.org/wiki/Manual:$wgCookieExpiration . Default: false.
 
 ```
 

--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -92,7 +92,7 @@ class SpecialOAuth2Client extends SpecialPage {
 	}
 
 	private function _handleCallback(){
-		global $wgRequest;
+		global $wgRequest, $wgOAuth2Client;
 
 		try {
 			$storedState = $wgRequest->getSession()->get('oauth2state');
@@ -117,7 +117,8 @@ class SpecialOAuth2Client extends SpecialPage {
 
 		$resourceOwner = $this->_provider->getResourceOwner($accessToken);
 		$user = $this->_userHandling( $resourceOwner->toArray() );
-		$user->setCookies();
+		$rememberMe = $wgOAuth2Client['configuration']['remember_me'] ?? false;
+		$user->setCookies(null, null, $rememberMe);
 
 		global $wgOut, $wgRequest;
 		$title = null;
@@ -196,7 +197,8 @@ class SpecialOAuth2Client extends SpecialPage {
 
 		// Setup the session
 		$wgRequest->getSession()->persist();
-		$user->setCookies();
+		$rememberMe = $wgOAuth2Client['configuration']['remember_me'] ?? false;
+		$user->setCookies(null, null, $rememberMe);
 		$this->getContext()->setUser( $user );
 		$user->saveSettings();
 		RequestContext::getMain()->setUser( $user );


### PR DESCRIPTION
## Checklist
- [x] Completed all template sections below
- [ ] Added a label to PR to specify the type - (I don't think I can add labels?)

## Overview

Add new optional config option:
$wgOAuth2Client['configuration']['remember_me']

It controls whether the users should be logged in the way they would if they checked the "Keep me logged in" checkbox in password-based authentication. Basically, the cookies are then set a bit differently, as described in https://www.mediawiki.org/wiki/Manual:$wgCookieExpiration

The default is false, so the behaviour from before this patch is preserved.

This is useful, as without it in some setups the user will be logged in only for a short period of time, which makes e.g. editing experience pretty annoying.

## Testing

- [ ] Includes additional automatic tests
- [x] Did manual tests

Logged in with the option set to true & false, compared cookies, compared logout time.

## Screenshots

When enabled, the Token cookie is set as well:

![image](https://github.com/user-attachments/assets/d7c3ca50-312c-412d-956d-0177b723d064)
